### PR TITLE
fix type of rspec let of $::operatingsystemmajrelease

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ class yum_autoupdate (
     $debug_level_real = $debug_level
   }
 
-  if $::operatingsystem != 'Fedora' and $::operatingsystemmajrelease < '7' {
+  if $::operatingsystem != 'Fedora' and $::operatingsystemmajrelease < 7 {
     $exclude_real = join(prefix($exclude, '--exclude='), '\ ')
   } else {
     $exclude_real = join($exclude, ' ')
@@ -134,7 +134,7 @@ class yum_autoupdate (
 
   # clear default hourly schedule on recent OSes
   # it can be recreated and customized using a 'schedule' resource
-  if $::operatingsystem == 'Fedora' or ($::operatingsystem != 'Fedora' and $::operatingsystemmajrelease >= '7') {
+  if $::operatingsystem == 'Fedora' or ($::operatingsystem != 'Fedora' and $::operatingsystemmajrelease >= 7) {
     unless $keep_default_hourly {
       file { ['/etc/yum/yum-cron-hourly.conf', '/etc/cron.hourly/0yum-hourly.cron']: ensure => absent }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class yum_autoupdate::params {
       case $::operatingsystem {
         'Fedora' : {
           case $::operatingsystemmajrelease {
-            /^(19|20|21)$/ : {
+            19,20,21       : {
               $default_config_path = '/etc/yum/yum-cron.conf'
               $default_schedule_path = '/etc/cron.daily/0yum-daily.cron'
               $conf_tpl = 'rhel7.erb'
@@ -21,17 +21,17 @@ class yum_autoupdate::params {
         # all other RHEL-based OS
         default  : {
           case $::operatingsystemmajrelease {
-            '7'     : {
+            7       : {
               $default_config_path = '/etc/yum/yum-cron.conf'
               $default_schedule_path = '/etc/cron.daily/0yum-daily.cron'
               $debug_level = -1
             }
-            '6'     : {
+            6       : {
               $default_config_path = '/etc/sysconfig/yum-cron'
               $default_schedule_path = '/etc/cron.daily/0yum.cron'
               $debug_level = 1
             }
-            '5'     : {
+            5       : {
               $default_config_path = '/etc/sysconfig/yum-cron'
               $default_schedule_path = '/etc/cron.daily/yum.cron'
               $debug_level = 1

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -4,7 +4,7 @@ describe 'yum_autoupdate::params' do
   let :facts do
     {
       :osfamily                  => 'RedHat',
-      :operatingsystemmajrelease => '7',
+      :operatingsystemmajrelease => 7,
       :operatingsystem           => 'RedHat'
     }
   end

--- a/spec/classes/yum_autoupdate_spec.rb
+++ b/spec/classes/yum_autoupdate_spec.rb
@@ -4,7 +4,7 @@ describe 'yum_autoupdate' do
   let :facts do
     {
       :osfamily                  => 'RedHat',
-      :operatingsystemmajrelease => '7',
+      :operatingsystemmajrelease => 7,
       :operatingsystem           => 'RedHat'
     }
   end
@@ -27,7 +27,7 @@ describe 'yum_autoupdate' do
     context 'on RedHat 5' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '5'
+          :operatingsystemmajrelease => 5
         })
       end
       it do
@@ -58,7 +58,7 @@ describe 'yum_autoupdate' do
     context 'on RedHat 6' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '6'
+          :operatingsystemmajrelease => 6
         })
       end
       it do
@@ -118,7 +118,7 @@ describe 'yum_autoupdate' do
     context 'on Fedora' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '21',
+          :operatingsystemmajrelease => 21,
           :operatingsystem           => 'Fedora'
         })
       end
@@ -160,7 +160,7 @@ describe 'yum_autoupdate' do
     context 'on RedHat 5' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '5'
+          :operatingsystemmajrelease => 5
         })
       end
       ['yum-cron default config', 'yum-cron default schedule'].each do |daily_files|
@@ -173,7 +173,7 @@ describe 'yum_autoupdate' do
     context 'on RedHat 6' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '6'
+          :operatingsystemmajrelease => 6
         })
       end
       ['yum-cron default config', 'yum-cron default schedule'].each do |daily_files|
@@ -197,7 +197,7 @@ describe 'yum_autoupdate' do
     context 'on Fedora' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '21',
+          :operatingsystemmajrelease => 21,
           :operatingsystem           => 'Fedora'
         })
       end
@@ -216,7 +216,7 @@ describe 'yum_autoupdate' do
       context 'on RedHat 5' do
         let :facts do
           super().merge({
-            :operatingsystemmajrelease => '5'
+            :operatingsystemmajrelease => 5
           })
         end
         it 'expect valid content' do
@@ -226,7 +226,7 @@ describe 'yum_autoupdate' do
       context 'on RedHat 6' do
         let :facts do
           super().merge({
-            :operatingsystemmajrelease => '6'
+            :operatingsystemmajrelease => 6
           })
         end
         it 'expect valid content' do
@@ -256,7 +256,7 @@ describe 'yum_autoupdate' do
       context 'on RedHat 5' do
         let :facts do
           super().merge({
-            :operatingsystemmajrelease => '5'
+            :operatingsystemmajrelease => 5
           })
         end
         it 'expect valid content' do
@@ -266,7 +266,7 @@ describe 'yum_autoupdate' do
       context 'on RedHat 6' do
         let :facts do
           super().merge({
-            :operatingsystemmajrelease => '6'
+            :operatingsystemmajrelease => 6
           })
         end
         it 'expect valid content' do

--- a/spec/defines/schedule_spec.rb
+++ b/spec/defines/schedule_spec.rb
@@ -6,7 +6,7 @@ describe 'yum_autoupdate::schedule' do
   let :facts do
     {
       :osfamily                  => 'RedHat',
-      :operatingsystemmajrelease => '7',
+      :operatingsystemmajrelease => 7,
       :operatingsystem           => 'RedHat'
     }
   end
@@ -18,7 +18,7 @@ describe 'yum_autoupdate::schedule' do
     context 'on RedHat 5' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '5'
+          :operatingsystemmajrelease => 5
         })
       end
       it do
@@ -32,7 +32,7 @@ describe 'yum_autoupdate::schedule' do
     context 'on RedHat 6' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '6'
+          :operatingsystemmajrelease => 6
         })
       end
       it do
@@ -56,7 +56,7 @@ describe 'yum_autoupdate::schedule' do
     context 'on Fedora' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '21',
+          :operatingsystemmajrelease => 21,
           :operatingsystem           => 'Fedora'
         })
       end
@@ -105,7 +105,7 @@ describe 'yum_autoupdate::schedule' do
     context 'on RedHat 5' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '5'
+          :operatingsystemmajrelease => 5
         })
       end
       it do
@@ -120,7 +120,7 @@ describe 'yum_autoupdate::schedule' do
     context 'on RedHat 6' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '6'
+          :operatingsystemmajrelease => 6
         })
       end
       it do
@@ -146,7 +146,7 @@ describe 'yum_autoupdate::schedule' do
     context 'on Fedora' do
       let :facts do
         super().merge({
-          :operatingsystemmajrelease => '21',
+          :operatingsystemmajrelease => 21,
           :operatingsystem           => 'Fedora'
         })
       end
@@ -165,7 +165,7 @@ describe 'yum_autoupdate::schedule' do
       context 'on RedHat 5' do
         let :facts do
           super().merge({
-            :operatingsystemmajrelease => '5'
+            :operatingsystemmajrelease => 5
           })
         end
         it 'expect valid content' do
@@ -175,7 +175,7 @@ describe 'yum_autoupdate::schedule' do
       context 'on RedHat 6' do
         let :facts do
           super().merge({
-            :operatingsystemmajrelease => '6'
+            :operatingsystemmajrelease => 6
           })
         end
         it 'expect valid content' do
@@ -205,7 +205,7 @@ describe 'yum_autoupdate::schedule' do
       context 'on RedHat 5' do
         let :facts do
           super().merge({
-            :operatingsystemmajrelease => '5'
+            :operatingsystemmajrelease => 5
           })
         end
         it 'expect valid content' do
@@ -215,7 +215,7 @@ describe 'yum_autoupdate::schedule' do
       context 'on RedHat 6' do
         let :facts do
           super().merge({
-            :operatingsystemmajrelease => '6'
+            :operatingsystemmajrelease => 6
           })
         end
         it 'expect valid content' do


### PR DESCRIPTION
This fact is properly an Integer instead of a String.  This correction is
needed for puppet 4 compatibility, which no longer allows numeric comparision
(via implicit type conversion) of strings.