### PR TITLE
remove extra whitespace in metadata.json version_requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 1.0.0  < 5.0.0"
+      "version_requirement": ">= 1.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
To resolve this error seen with librarian-puppet / vagrant-librarian-puppet:
    /opt/vagrant/embedded/lib/ruby/2.0.0/rubygems/requirement.rb:90:in `parse': Illformed requirement [">= 1.0.0  < 5.0.0"] (Gem::Requirement::BadRequirementError)