### PR TITLE
added yum_params for RHEL 5 & 6 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+###0.6.2
+
+* Fix compatibility with Puppet 2.7 ([jenkins101](https://github.com/jenkins101))
+* Partial revert of changes introduced in v0.6.1 (Puppet 4.x)
+
 ###0.6.1
 
 * Fix compatibility with Puppet 4.0 ([jhoblitt](https://github.com/jhoblitt))
@@ -26,7 +31,7 @@ Fix compatibility with future parser in Puppet 3.7.4 ([PUP-3615](https://tickets
 
 ###0.4.0
 
-* `update_cmd` can now be defined (thanks [Kim](https://github.com/ksaio)!)
+* `update_cmd` can now be defined ([ksaio](https://github.com/ksaio)!)
 * Deletion of the default hourly schedule on RHEL 7/Fedora 19+
 * Make Puppet Doc compliant with RDoc markup language
 * Refactoring

--- a/README.md
+++ b/README.md
@@ -229,5 +229,6 @@ Check the [puppetlabs_spec_helper](https://github.com/puppetlabs/puppetlabs_spec
 
 * [Kim Stig Andersen](https://github.com/ksaio)
 * [Joshua Hoblitt](https://github.com/jhoblitt)
+* [Daniel Forsberg](https://github.com/jenkins101)
 
 Features request and contributions are always welcome!

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,8 @@
 #   mode in which yum-cron should perform (valid: 'check', 'download', 'apply')
 # [*exclude*]
 #   packages to exclude from automatic update (array)
+# [*yum_params*]
+#   any extra yum cmdline parameters like --disablerepo= (only supported on RHEL 5 & 6)
 # [*notify_email*]
 #   enable email notifications (boolean)
 # [*email_to*]
@@ -56,6 +58,7 @@ class yum_autoupdate (
   $keep_default_hourly = false,
   $action              = 'apply',
   $exclude             = [],
+  $yum_params          = '',
   $notify_email        = true,
   $email_to            = 'root',
   $email_from          = 'root',
@@ -68,7 +71,7 @@ class yum_autoupdate (
   validate_bool($service_enable, $notify_email, $default_schedule, $keep_default_hourly)
   validate_re($action, '^(check|download|apply)$', '$action must be either \'check\', \'download\' or \'apply\'')
   validate_array($exclude)
-  validate_string($email_to, $email_from, $update_cmd)
+  validate_string($email_to, $email_from, $update_cmd, $yum_params)
   if ($debug_level < -1) or ($debug_level > 10) { fail('$debug_level must be a number between -1 and 10') }
   if ($error_level < 0) or ($error_level > 10) { fail('$error_level must be a number between 0 and 10') }
   validate_re($update_cmd, '^(default|security|security-severity:Critical|minimal|minimal-security|minimal-security-severity:Critical)$', '$update_cmd must be either \'default\', \'security\', \'security-severity:Critical\', \'minimal\', \'minimal-security\' or \'minimal-security-severity:Critical\'')

--- a/manifests/schedule.pp
+++ b/manifests/schedule.pp
@@ -8,6 +8,8 @@
 #   mode in which yum-cron should perform (valid: 'check', 'download', 'apply')
 # [*exclude*]
 #   packages to exclude from automatic update (array)
+# [*yum_params*]
+#   any extra yum cmdline parameters like --disablerepo= (only supported on RHEL 5 & 6)
 # [*notify_email*]
 #   enable email notifications (boolean)
 # [*email_to*]
@@ -57,6 +59,7 @@
 define yum_autoupdate::schedule (
   $action       = 'apply',
   $exclude      = [],
+  $yum_params   = '',
   $notify_email = true,
   $email_to     = 'root',
   $email_from   = 'root',
@@ -81,7 +84,7 @@ define yum_autoupdate::schedule (
   validate_re($action, '^(check|download|apply)$', '$action must be either \'check\', \'download\' or \'apply\'')
   validate_array($exclude)
   validate_bool($notify_email)
-  validate_string($email_to, $email_from, $update_cmd)
+  validate_string($email_to, $email_from, $update_cmd, $yum_params)
   if ($debug_level < -1) or ($debug_level > 10) { fail('$debug_level must be a number between -1 and 10') }
   if ($error_level < 0) or ($error_level > 10) { fail('$error_level must be a number between 0 and 10') }
   validate_re($update_cmd, '^(default|security|security-severity:Critical|minimal|minimal-security|minimal-security-severity:Critical)$', '$update_cmd must be either \'default\', \'security\', \'security-severity:Critical\', \'minimal\', \'minimal-security\' or \'minimal-security-severity:Critical\'')

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "project_page": "https://github.com/antoineco/aco-yum_autoupdate",
   "source": "git://github.com/antoineco/aco-yum_autoupdate.git",
   "summary": "Puppet module for scheduled system updates on RHEL variants",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "tags": ["unattended","update","yum"],
   "dependencies": [
     {

--- a/templates/conf/rhel5.erb
+++ b/templates/conf/rhel5.erb
@@ -2,7 +2,7 @@
 # Managed by Puppet
 # ******************
 
-YUM_PARAMETER=<%= @exclude_real %>
+YUM_PARAMETER=<% if ! @yum_params.empty? -%>"<%= @yum_params %> "<% end %><%= @exclude_real %>
 CHECK_ONLY=<% if @action == 'check' -%>yes<% else -%>no<% end %>
 DOWNLOAD_ONLY=<% if @action == 'download' -%>yes<% else -%>no<% end %>
 ERROR_LEVEL=<%= @error_level %>

--- a/templates/conf/rhel6.erb
+++ b/templates/conf/rhel6.erb
@@ -2,7 +2,7 @@
 # Managed by Puppet
 # ******************
 
-YUM_PARAMETER=<%= @exclude_real %>
+YUM_PARAMETER=<% if ! @yum_params.empty? -%>"<%= @yum_params %> "<% end %><%= @exclude_real %>
 CHECK_ONLY=<% if @action == 'check' -%>yes<% else -%>no<% end %>
 DOWNLOAD_ONLY=<% if @action == 'download' -%>yes<% else -%>no<% end %>
 CHECK_FIRST=no


### PR DESCRIPTION
yum-cron in RHEL 7 and Fedora don't support this.

This makes it possible to set any yum parameter for RHEL 5 and 6

@antoineco I am no good at the rspec stuff, do I need to do something there?
