### PR TITLE
don't require specific Fedora versions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,17 +5,15 @@ class yum_autoupdate::params {
     'RedHat' : {
       case $::operatingsystem {
         'Fedora' : {
-          case $::operatingsystemmajrelease {
-            '19','20','21','22' : {
-              $default_config_path = '/etc/yum/yum-cron.conf'
-              $default_schedule_path = '/etc/cron.daily/0yum-daily.cron'
-              $conf_tpl = 'rhel7.erb'
-              $schedule_tpl = 'rhel7.erb'
-              $debug_level = -1
-            }
-            default             : {
-              fail("Unsupported OS version ${::operatingsystemmajrelease}")
-            }
+          if $::operatingsystemmajrelease >= '19' {
+            $default_config_path = '/etc/yum/yum-cron.conf'
+            $default_schedule_path = '/etc/cron.daily/0yum-daily.cron'
+            $conf_tpl = 'rhel7.erb'
+            $schedule_tpl = 'rhel7.erb'
+            $debug_level = -1
+          }
+          else {
+            fail("Unsupported OS version ${::operatingsystemmajrelease}")
           }
         }
         # all other RHEL-based OS


### PR DESCRIPTION
Would this be acceptable? Or maybe leave it at a minimum version of fedora? Given they release every ~6 months or so, this likely to break things more often than not if the list of supported versions isn't kept up to date.

Seems to work fine for me on fedora 23.